### PR TITLE
Increase the waiting time between attempts

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -11,12 +11,12 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v3
-  
+
         - name: Link Checker
           id: lychee
           uses: lycheeverse/lychee-action@v1.8.0
           with:
-            args: --verbose https://blockchain.netz39.de/
+            args: --verbose --retry-wait-time 30 https://blockchain.netz39.de/
 
         - name: Create Issue From File
           if: env.lychee_exit_code != 0


### PR DESCRIPTION
Per default lychee retries after 1 second if a website access fails. This may be too short for transient problems to be fixed.

Increase the time between attempts to reduce false positives on transient failures.