### PR TITLE
Run the Link Checker only once a week

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -4,7 +4,7 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "00 18 * * *"
+    - cron: "00 18 * * 5"
 
 jobs:
     linkChecker:


### PR DESCRIPTION
Running only once a week is sufficient. We do not have this much traffic on the page.

Also rename the workflow to be more descriptive.