### PR TITLE
Set up Dependabot to update the GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This pull request adds a basic Dependabot configuration to the repository to enable automated updates for GitHub Actions dependencies.

Dependency management:

* Added a `.github/dependabot.yml` file to configure Dependabot for weekly checks and updates of GitHub Actions dependencies, labeling relevant pull requests with "dependencies".